### PR TITLE
[hotfix] #4+のdescriptionで記号がエスケープされていない問題の修正

### DIFF
--- a/_posts/2021-02-21-4.5.md
+++ b/_posts/2021-02-21-4.5.md
@@ -8,7 +8,7 @@ audio_file_path: /audio/4plus.mp3
 audio_file_size: 24726979
 date: 2021-02-21 17:00:00 +0900
 record-date: 2021-01-22
-description: もともと第4回として収録した aoiroaoino 氏のScalaトークが想定以上の面白さ&時間超過だったので、第4回のアフタートークとして配信します。まみむメモは技術系Podcastです。
+description: もともと第4回として収録した aoiroaoino 氏のScalaトークが想定以上の面白さ&amp;時間超過だったので、第4回のアフタートークとして配信します。まみむメモは技術系Podcastです。
 duration: "20:29"
 layout: article
 title: 4+. あおいの氏にScalaについて語ってもらい、技術系Podcastの本領を発揮しました (第4回aftertalk)


### PR DESCRIPTION
```
This page contains the following errors:
error on line 55 at column 121: EntityRef: expecting ';'
Below is a rendering of the page up to the first error.
```